### PR TITLE
Fix AWS_SETUP running when it shouldn't

### DIFF
--- a/autobuilder/scripts/headConfigurator.sh
+++ b/autobuilder/scripts/headConfigurator.sh
@@ -10,9 +10,9 @@ CWD=$1
 cd $CWD
 
 if [ -z "$AWS_SECRET_ACCESS_KEY" ] && [ -z "$AWS_ACCESS_KEY_ID" ]; then
-    RUN_ANNEX_SETUP=true
-else
     RUN_ANNEX_SETUP=false
+else
+    RUN_ANNEX_SETUP=true
 fi
 
 


### PR DESCRIPTION
Annex setup would reliably run when it shouldn't - which happens when you tell it to run every time it shouldn't.