### PR TITLE
Remove dependency on original autobuilder repo.

### DIFF
--- a/autobuilder/scripts/autobuilder.sh
+++ b/autobuilder/scripts/autobuilder.sh
@@ -51,5 +51,5 @@ sudo systemctl enable condor-annex-ec2
 cd $CWD
 mkdir -p .install
 mv RPM-GPG-KEY-HTCondor pegasus-5.0.0-1.el8.x86_64.rpm -t .install/
-mv -n autobuilder -t .install/
+mv -n RubinAWS -t .install/
 

--- a/autobuilder/scripts/baseInstaller.sh
+++ b/autobuilder/scripts/baseInstaller.sh
@@ -20,7 +20,7 @@ sudo dnf config-manager --set-enabled powertools
 sudo yum update -y
 sudo yum install -y curl patch wget git diffutils java
 
-git clone -b packer https://github.com/DinoBektesevic/autobuilder.git
+git clone https://github.com/astronomy-commons/RubinAWS.git
 
 
 ####

--- a/autobuilder/scripts/headConfigurator.sh
+++ b/autobuilder/scripts/headConfigurator.sh
@@ -19,8 +19,8 @@ fi
 ####
 #   1) Configure instance as HTCondor head node
 ####
-sudo cp ~/autobuilder/configs/condor_head_config /etc/condor/config.d/local
-sudo cp ~/autobuilder/configs/condor_annex_ec2 /usr/libexec/condor/condor-annex-ec2
+sudo cp ~/RubinAWS/autobuilder/configs/condor_head_config /etc/condor/config.d/local
+sudo cp ~/RubinAWS/autobuilder/configs/condor_annex_ec2 /usr/libexec/condor/condor-annex-ec2
 
 #   1.1) Configure a Condor Pool Password.
 #        Both Condor and Condor Annex need the condor pool password. But Condor needs it
@@ -40,9 +40,9 @@ sudo chown root $passwd_file_path
 sudo chown $USER ~/.condor/condor_pool_password
 
 #   1.2) Set up an HTCondor S3 Transfer Plugin
-sudo cp ~/autobuilder/configs/s3.sh /usr/libexec/condor/s3.sh
+sudo cp ~/RubinAWS/autobuilder/configs/s3.sh /usr/libexec/condor/s3.sh
 sudo chmod 755 /usr/libexec/condor/s3.sh
-sudo cp ~/autobuilder/configs/10_s3 /etc/condor/config.d/10-s3
+sudo cp ~/RubinAWS/autobuilder/configs/10_s3 /etc/condor/config.d/10-s3
 
 #   1.3) Configure Condor Annex Defaults. If credentials are non-empty strings
 #        configure keys so that Condor Annex can succesfully run. Keys are cleanued
@@ -77,7 +77,7 @@ fi
 echo "# The following commands were added by Rubin AWS autobuilder." >> ~/.bashrc
 echo "source ~/lsst_stack/loadLSST.bash" >> ~/.bashrc
 echo "setup lsst_distrib" >> ~/.bashrc
-echo "source ~/.install/autobuilder/auth/authenticate.sh" >> ~/.bashrc
+echo "source ~/.install/RubinAWS/autobuilder/auth/authenticate.sh" >> ~/.bashrc
 
 
 ####

--- a/autobuilder/scripts/s3PluginInstaller.sh
+++ b/autobuilder/scripts/s3PluginInstaller.sh
@@ -8,12 +8,12 @@ cd $CWD
 #  This script will configure an S3 Transfer pluguin so that HTCondor
 #  is able to use S3 buckets to communicate and stage jobs.
 ####
-sudo cp ~/autobuilder/configs/s3.sh /usr/libexec/condor/s3.sh
+sudo cp ~/RubinAWS/autobuilder/configs/s3.sh /usr/libexec/condor/s3.sh
 sudo chmod 755 /usr/libexec/condor/s3.sh
-sudo cp ~/autobuilder/configs/10_s3 /etc/condor/config.d/10-s3
+sudo cp ~/RubinAWS/autobuilder/configs/10_s3 /etc/condor/config.d/10-s3
 
 ####
 #  Cleanup
 ####
 mkdir -p .install
-mv -nr autobuilder -t .install/
+mv -nr RubinAWS -t .install/

--- a/autobuilder/scripts/workerConfigurator.sh
+++ b/autobuilder/scripts/workerConfigurator.sh
@@ -14,7 +14,7 @@ cd $CWD
 #   1) Configure instance as HTCondor worker node
 ####
 cd $CWD
-sudo cp ~/autobuilder/configs/condor_worker_config /etc/condor/config.d/local
+sudo cp ~/RubinAWS/autobuilder/configs/condor_worker_config /etc/condor/config.d/local
 echo "SSH_TO_JOB_SSHD_CONFIG_TEMPLATE = /etc/condor/condor_ssh_to_job_sshd_config_template" >> /etc/condor_config
 sudo rm /etc/condor/config.d/50ec2.config
 


### PR DESCRIPTION
Remove dependency on [DinoBektesevic/autobuiler](https://github.com/DinoBektesevic/autobuilder). 

`RubinAWS/autobuilder/main` branch is now stable and only developed version.