### PR TITLE
Add authentication forwarding.

### DIFF
--- a/autobuilder/images/nodes.pkr.hcl
+++ b/autobuilder/images/nodes.pkr.hcl
@@ -147,7 +147,7 @@ build {
     provisioner "shell" {
         inline = [
           "chmod u+x /tmp/scripts/autobuilder.sh",
-          "/tmp/scripts/autobuilder.sh ${source.name} ${source.region}"
+          "/tmp/scripts/autobuilder.sh ${source.name} ${source.region} ${source.access_key} ${source.secret_key}"
         ]
     }
 }

--- a/autobuilder/scripts/autobuilder.sh
+++ b/autobuilder/scripts/autobuilder.sh
@@ -3,6 +3,8 @@ set -x
 
 BUILD_TYPE=$1
 export AWS_REGION=$2
+export AWS_ACCESS_KEY_ID=$3
+export AWS_SECRET_ACCESS_KEY=$4
 
 build_type="None"
 case $BUILD_TYPE in


### PR DESCRIPTION
We need credentials to successfully build Annex.

The credentials are cleaned by the build script before the AMI is made so hopefully it should be safe. Probably not smart though - but until HTCondor and Pegasus make using IAM authentication easy/possible it's the best I can do I think.