### PR TITLE
Fix condor annex setup

### DIFF
--- a/autobuilder/scripts/baseInstaller.sh
+++ b/autobuilder/scripts/baseInstaller.sh
@@ -26,9 +26,13 @@ sudo systemctl enable iptables
 sudo systemctl start ip6tables
 sudo systemctl enable ip6tables
 
+mkdir -p .awscli
+cd .awscli
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 sudo ./aws/install
+rm awscliv2.zip
+cd $CWD
 
 git clone https://github.com/astronomy-commons/RubinAWS.git
 

--- a/autobuilder/scripts/baseInstaller.sh
+++ b/autobuilder/scripts/baseInstaller.sh
@@ -18,7 +18,17 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.
 sudo dnf config-manager --set-enabled powertools
 
 sudo yum update -y
-sudo yum install -y curl patch wget git diffutils java
+sudo yum install -y curl patch wget git diffutils java unzip
+
+sudo yum install -y iptables-services
+sudo systemctl start iptables
+sudo systemctl enable iptables
+sudo systemctl start ip6tables
+sudo systemctl enable ip6tables
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
 
 git clone https://github.com/astronomy-commons/RubinAWS.git
 

--- a/autobuilder/scripts/headConfigurator.sh
+++ b/autobuilder/scripts/headConfigurator.sh
@@ -31,7 +31,7 @@ mkdir -p ~/.condor
 
 random_passwd=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
 passwd_file_path=`condor_config_val SEC_PASSWORD_FILE`
-sudo condor_store_cred add -f $passwd_file_path -p $random_passwd
+sudo condor_store_cred -c add -f $passwd_file_path -p $random_passwd
 
 sudo cp $passwd_file_path ~/.condor/
 
@@ -53,7 +53,7 @@ if [ $RUN_ANNEX_SETUP = true ]; then
     sudo chmod 600 ~/.condor/*KeyFile
 fi
 
-echo "SEC_PASSWORD_FILE=~/.condor/condor_pool_password" > ~/.condor/user_config
+echo "SEC_PASSWORD_FILE=${HOME}/.condor/condor_pool_password" > ~/.condor/user_config
 echo "ANNEX_DEFAULT_AWS_REGION=${AWS_REGION}" >> ~/.condor/user_config
 sudo chown $USER ~/.condor/user_config
 

--- a/autobuilder/scripts/workerConfigurator.sh
+++ b/autobuilder/scripts/workerConfigurator.sh
@@ -15,7 +15,7 @@ cd $CWD
 ####
 cd $CWD
 sudo cp ~/RubinAWS/autobuilder/configs/condor_worker_config /etc/condor/config.d/local
-echo "SSH_TO_JOB_SSHD_CONFIG_TEMPLATE = /etc/condor/condor_ssh_to_job_sshd_config_template" >> /etc/condor_config
+echo "SSH_TO_JOB_SSHD_CONFIG_TEMPLATE = /etc/condor/condor_ssh_to_job_sshd_config_template" >> /etc/condor/condor_config
 sudo rm /etc/condor/config.d/50ec2.config
 
 #   1.1) Restart Condor to reload config values. Run annex configurator.


### PR DESCRIPTION
Fixing condor annex discovered some minor bugs. 

For some reason while debugging it appeared to me as if iptables don't exist on CentOS8 anymore (but neither firewalld or nftables are either). So that is added - this should be investigated more. 

Added systemwide awscli just in case.